### PR TITLE
Fix user normalization and description handling

### DIFF
--- a/app/src/Entity/CheeseListing.php
+++ b/app/src/Entity/CheeseListing.php
@@ -128,6 +128,10 @@ class CheeseListing
      */
     public function getShortDescription(): ?string
     {
+        if (null === $this->description) {
+            return null;
+        }
+
         if (strlen($this->description) < 40) {
             return $this->description;
         }

--- a/app/src/Serializer/Normalizer/UserNormalizer.php
+++ b/app/src/Serializer/Normalizer/UserNormalizer.php
@@ -29,6 +29,9 @@ class UserNormalizer implements ContextAwareNormalizerInterface, CacheableSuppor
     {
         $isOwner = $this->userIsOwner($object);
         if ($isOwner) {
+            if (!\array_key_exists('groups', $context)) {
+                $context['groups'] = [];
+            }
             $context['groups'][] = 'owner:read';
         }
 


### PR DESCRIPTION
## Summary
- avoid undefined 'groups' index in `UserNormalizer`
- handle null description in `CheeseListing::getShortDescription`

## Testing
- `php vendor/bin/phpunit` *(fails: Could not open input file)*

------
https://chatgpt.com/codex/tasks/task_e_68779b8f487c832f9aab7721dc1b5304